### PR TITLE
addding_bfs

### DIFF
--- a/C++/adding_bfs.cpp
+++ b/C++/adding_bfs.cpp
@@ -1,0 +1,50 @@
+#include <bits/stdc++.h>
+using namespace std;
+
+vector<int> bfs_from_zero(int V, const vector<vector<int>>& adj) {
+    vector<int> order;
+    if (V <= 0) return order;
+
+    vector<char> vis(V, 0);
+    queue<int> q;
+
+    if (0 >= V) return order; // avoid starting node outside range
+    q.push(0);
+    vis[0] = 1;
+
+    while (!q.empty()) {
+        int u = q.front(); q.pop();
+        order.push_back(u);
+        for (int v : adj[u])
+            if (v >= 0 && v < V && !vis[v]) { vis[v] = 1; q.push(v); }
+    }
+    return order;
+}
+
+int main() {
+    // Example 1
+    int V1 = 5;
+    vector<vector<int>> adj1 = {{1,2},{},{3},{},{}};
+    auto o1 = bfs_from_zero(V1, adj1);
+    for (size_t i = 0; i < o1.size(); ++i) {
+        cout << o1[i] << (i + 1 == o1.size() ? '\n' : ' ');
+    }
+
+    // Example 2
+    int V2 = 3;
+    vector<vector<int>> adj2 = {{1,2},{},{}};
+    auto o2 = bfs_from_zero(V2, adj2);
+    for (size_t i = 0; i < o2.size(); ++i) {
+        cout << o2[i] << (i + 1 == o2.size() ? '\n' : ' ');
+    }
+
+    // Simple error checks (optional): demonstrate invalid input handling
+    // Example: invalid V
+    int V_invalid = -1;
+    auto invalid = bfs_from_zero(V_invalid, adj1);
+    if (invalid.empty()) {
+        cerr << "Error: invalid vertex count or unreachable start\n";
+    }
+
+    return 0;
+}


### PR DESCRIPTION
The function bfs_from_zero performs a breadth-first search starting from vertex 0 on a given adjacency list adj of a graph with V vertices.
It returns the traversal order as a vector of vertex indices.
The implementation ensures safety checks:
Returns an empty order if V <= 0
Guards against starting outside the valid range
Only visits valid, unvisited neighbors within [0, V-1]
The main function provides two example graphs and prints their BFS orders:
Example 1: V1 = 5, adj1 = {{1,2},{},{3},{}, {}}
Example 2: V2 = 3, adj2 = {{1,2},{},{}}
A simple error-checking demonstration shows behavior for an invalid V (negative vertex count).
